### PR TITLE
Improve resolution of YouTube video thumbnail in `README.md` from (320x180 to 1280x720)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1>Encrypt Git Repositories</h1>
   <p>Guide to using encrypted Git remotes with the help of git-remote-gcrypt</p>
   <a href="https://youtu.be/XdoTca3EQGU">
-    <img width="320px" height="180px" src="https://img.youtube.com/vi/XdoTca3EQGU/mqdefault.jpg" style="border-radius: 1rem;" />
+    <img width="320px" height="180px" src="https://i.ytimg.com/vi/XdoTca3EQGU/maxresdefault.jpg" style="border-radius: 1rem;" />
     <p>Watch the YouTube Tutorial</p>
   </a>
 </div>


### PR DESCRIPTION
Before after screenshot:

![image](https://github.com/flolu/git-gcrypt/assets/12752145/e3139738-7c25-4f5e-8dd7-be3165dc3533)

Note that on my Framework laptop the initial image was rendered with a x2 bigger factor than the declared resolution. Note that I am running Linux Mint with `User interface scale` set to `200 %`.

![](https://github.com/flolu/git-gcrypt/assets/12752145/f7095e96-9228-4ae8-a146-194a127fd4b7)


Maybe it is a too high resolution thumbnail, but at least it is not pixelated as before.

Note that modifying [`width`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#width) and [`height`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#height) modify the actual rendering size of the image which is not something wanted here.

Also note that I do not know if the URL used can at some point provide a better thumbnail resolution which may then be unwanted.